### PR TITLE
:sparkles: Updated serializer for idol, added permission for write

### DIFF
--- a/Idols/permissions.py
+++ b/Idols/permissions.py
@@ -1,0 +1,21 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsAdminOrReadOnly(BasePermission):
+    """
+    관리자 등급은 쓰기 권한, 일반 유저는 읽기 권한만 부여
+    """
+
+    def has_permission(self, request, view):
+        if request.method in ["GET"]:
+            return True  # 모두 읽기 허용
+        return request.user and request.user.is_staff
+
+
+class IsSuperUser(BasePermission):
+    """
+    요청한 사용자가 슈퍼유저인지 확인
+    """
+
+    def has_permission(self, request, view):
+        return request.user and request.user.is_superuser

--- a/Idols/urls.py
+++ b/Idols/urls.py
@@ -5,9 +5,15 @@ from .views import AgencyListView, GroupListView, IdolListView
 urlpatterns = [
     # 에이전시 리스트
     path("agencies/", AgencyListView.as_view(), name="agency_list"),
-    path("agencies/<str:name>/", AgencyListView.as_view(), name="agency_list_name"),
+    path("agencies/<int:pk>/", AgencyListView.as_view(), name="agency_detail"),
     # 그룹 리스트
     path("groups/", GroupListView.as_view(), name="group_list"),
+    path(
+        "groups/<int:pk>/", GroupListView.as_view(), name="group_detail"
+    ),  # 삭제 요청을 위한 pk 추가
     # 아이돌 리스트
     path("idols/", IdolListView.as_view(), name="idol_list"),
+    path(
+        "idols/<int:pk>/", IdolListView.as_view(), name="idol_detail"
+    ),  # 삭제 요청을 위한 pk 추가
 ]

--- a/Idols/views.py
+++ b/Idols/views.py
@@ -1,17 +1,28 @@
+from django.db.models import Count
+from django.shortcuts import get_object_or_404
 from rest_framework import status
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .models import Agency, Group, Idol
+from .permissions import IsAdminOrReadOnly, IsSuperUser
 from .serializers import AgencySerializer, GroupSerializer, IdolSerializer
 
 
 # 에이전시 리스트
 class AgencyListView(APIView):
+    def get_permissions(self):
+        if self.request.method == "GET":
+            return [AllowAny()]  # 읽기는 모든 유저 허용
+        return [IsSuperUser()]  # Post/Delete는 슈퍼유저만 허용
+
     def get(self, request):
         agencies = Agency.objects.all()
         serializer = AgencySerializer(agencies, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    permission_classes = [IsSuperUser]
 
     def post(self, request):
         serializer = AgencySerializer(data=request.data)
@@ -20,11 +31,22 @@ class AgencyListView(APIView):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    def delete(self, request, pk):
+        agency = get_object_or_404(Agency, pk=pk)
+        agency.delete()
+        return Response(
+            {"message": "소속사가 삭제되었습니다."}, status=status.HTTP_200_OK
+        )
+
 
 # 그룹 리스트
 class GroupListView(APIView):
+    permission_classes = [IsAdminOrReadOnly]
+
     def get(self, request):
-        groups = Group.objects.select_related("agency").all()
+        groups = Group.objects.select_related("agency").annotate(
+            member_count=Count("idol")
+        )
         serializer = GroupSerializer(groups, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -35,17 +57,35 @@ class GroupListView(APIView):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    def delete(self, request, pk=None):
+        group = get_object_or_404(Group, pk=pk)
+        group.delete()
+        return Response(
+            {"message": "그룹 삭제가 완료되었습니다."}, status=status.HTTP_200_OK
+        )
+
 
 # 아이돌 리스트
 class IdolListView(APIView):
+    permission_classes = [IsAdminOrReadOnly]
+
     def get(self, request):
         idols = Idol.objects.select_related("group").all()
         serializer = IdolSerializer(idols, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    # 아이돌 리스트 동일 적용
     def post(self, request):
         serializer = IdolSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, pk=None):
+        idol = get_object_or_404(Idol, pk=pk)
+        idol.delete()
+        return Response(
+            {"message": "요청하신 아이돌 삭제가 완료되었습니다."},
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
Updated serializer for idol
added permission

-------

시리얼라이저 로직 개선으로 아이돌 등록 시 같은 그룹 내에 동일 이름의 아이돌을 등록하려고 하면 실패하도록 만들었습니다.
Get은 누구나 가능하지만 Post 와 Delete는 admin 또는 staff가 아니면 불가능하도록 코드를 개선하였습니다.
group 조회시 확인되는 response의 형태를 개선하였습니다.