### PR TITLE
:sparkles: Created permission and serializer for Schedules

### DIFF
--- a/Schedules/permissions.py
+++ b/Schedules/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsAdminOrReadOnly(BasePermission):
+    """
+    관리자 등급은 쓰기 권한, 일반 유저는 읽기 권한만 부여
+    """
+
+    def has_permission(self, request, view):
+        if request.method in ["GET"]:
+            return True  # 모두 읽기 허용
+        return request.user and request.user.is_staff

--- a/Schedules/serializer.py
+++ b/Schedules/serializer.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from Idols.models import Group, Idol
+
+from .models import Schedule
+
+
+class ScheduleSerializer(serializers.ModelSerializer):
+    group = serializers.PrimaryKeyRelatedField(queryset=Group.objects.all())
+    participating_members = serializers.SlugRelatedField(
+        many=True, slug_field="name", queryset=Idol.objects.all()
+    )
+
+    class Meta:
+        model = Schedule
+        fields = "__all__"

--- a/Schedules/urls.py
+++ b/Schedules/urls.py
@@ -4,8 +4,8 @@ from .views import *
 
 urlpatterns = [
     path("", ScheduleListView.as_view(), name="schedule"),
-    path("<int:pk>/", ScheduleDetailView.as_view(), name="schedule_detail"),
     path("create/", ScheduleCreateView.as_view(), name="schedule_create"),
+    path("<int:pk>/", ScheduleDetailView.as_view(), name="schedule_detail"),
     path("<int:pk>/update/", ScheduleUpdateView.as_view(), name="schedule_update"),
     path(
         "group/<int:group_id>/", GroupScheduleListView.as_view(), name="group_schedule"


### PR DESCRIPTION
Created permission and serializer for Schedules

------

스케줄의 생성, 업데이트 및 삭제를 진행하려면 권한이 있어야 하도록 수정했습니다.
코드 직렬화와 유효성 검증을 위해 serializer를 생성
postman을 통해 테스트 완료하였습니다.