### PR TITLE
250324 스케줄 코드 리펙토링

### DIFF
--- a/Schedules/serializer.py
+++ b/Schedules/serializer.py
@@ -7,7 +7,7 @@ from .models import Schedule
 
 
 class ScheduleSerializer(serializers.ModelSerializer):
-    participating_members = serializers.PrimaryKeyRelatedField(many=True, queryset=Idol.objects.all())
+    participating_members = IdolSerializer(many=True, read_only=True)
     group = serializers.PrimaryKeyRelatedField(queryset=Group.objects.all())
 
     class Meta:
@@ -18,4 +18,3 @@ class ScheduleSerializer(serializers.ModelSerializer):
         if data ['end_time'] <= data['start_time']:
             raise serializers.ValidationError("end_time은 start_time 이후여야 합니다.")
         return data
-

--- a/Schedules/serializer.py
+++ b/Schedules/serializer.py
@@ -7,9 +7,15 @@ from .models import Schedule
 
 
 class ScheduleSerializer(serializers.ModelSerializer):
-    participating_members = IdolSerializer(many=True, read_only=True)
+    participating_members = serializers.PrimaryKeyRelatedField(many=True, queryset=Idol.objects.all())
+    group = serializers.PrimaryKeyRelatedField(queryset=Group.objects.all())
 
     class Meta:
         model = Schedule
         fields = ["group", "title", "description", "location", "start_time", "end_time", "participating_members"]
+
+    def validate(self,data):
+        if data ['end_time'] <= data['start_time']:
+            raise serializers.ValidationError("end_time은 start_time 이후여야 합니다.")
+        return data
 

--- a/Schedules/serializer.py
+++ b/Schedules/serializer.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
+
 from Idols.models import Group, Idol
+
 from .models import Schedule
+
 
 class ScheduleSerializer(serializers.ModelSerializer):
     # 참여 멤버를 이름 반환
@@ -13,8 +16,14 @@ class ScheduleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Schedule
         fields = [
-            "group", "title", "description", "location",
-            "start_time", "end_time", "participating_members", "participating_member_ids"
+            "group",
+            "title",
+            "description",
+            "location",
+            "start_time",
+            "end_time",
+            "participating_members",
+            "participating_member_ids",
         ]
 
     def create(self, validated_data):
@@ -26,7 +35,9 @@ class ScheduleSerializer(serializers.ModelSerializer):
         participating_members = validated_data.pop("participating_member_ids", [])
         validated_data["user"] = request.user  # 사용자 설정
         schedule = Schedule.objects.create(**validated_data)
-        schedule.participating_members.set(participating_members)  # ManyToMany 관계 설정
+        schedule.participating_members.set(
+            participating_members
+        )  # ManyToMany 관계 설정
         return schedule
 
     def get_participating_members(self, obj):

--- a/Schedules/serializer.py
+++ b/Schedules/serializer.py
@@ -1,16 +1,15 @@
 from rest_framework import serializers
 
 from Idols.models import Group, Idol
+from Idols.serializers import IdolSerializer
 
 from .models import Schedule
 
 
 class ScheduleSerializer(serializers.ModelSerializer):
-    group = serializers.PrimaryKeyRelatedField(queryset=Group.objects.all())
-    participating_members = serializers.SlugRelatedField(
-        many=True, slug_field="name", queryset=Idol.objects.all()
-    )
+    participating_members = IdolSerializer(many=True, read_only=True)
 
     class Meta:
         model = Schedule
-        fields = "__all__"
+        fields = ["group", "title", "description", "location", "start_time", "end_time", "participating_members"]
+

--- a/Schedules/serializer.py
+++ b/Schedules/serializer.py
@@ -1,20 +1,40 @@
 from rest_framework import serializers
-
 from Idols.models import Group, Idol
-from Idols.serializers import IdolSerializer
-
 from .models import Schedule
 
-
 class ScheduleSerializer(serializers.ModelSerializer):
-    participating_members = IdolSerializer(many=True, read_only=True)
+    # 참여 멤버를 이름 반환
+    participating_members = serializers.SerializerMethodField()
     group = serializers.PrimaryKeyRelatedField(queryset=Group.objects.all())
+    participating_member_ids = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=Idol.objects.all(), write_only=True
+    )  # 저장 시 사용할 ID 필드
 
     class Meta:
         model = Schedule
-        fields = ["group", "title", "description", "location", "start_time", "end_time", "participating_members"]
+        fields = [
+            "group", "title", "description", "location",
+            "start_time", "end_time", "participating_members", "participating_member_ids"
+        ]
 
-    def validate(self,data):
-        if data ['end_time'] <= data['start_time']:
+    def create(self, validated_data):
+        # 요청하는 사용자 가져오기
+        request = self.context.get("request")
+        if not request or not hasattr(request, "user"):
+            raise serializers.ValidationError("User context is missing.")
+
+        participating_members = validated_data.pop("participating_member_ids", [])
+        validated_data["user"] = request.user  # 사용자 설정
+        schedule = Schedule.objects.create(**validated_data)
+        schedule.participating_members.set(participating_members)  # ManyToMany 관계 설정
+        return schedule
+
+    def get_participating_members(self, obj):
+        # 참여 멤버의 이름만 반환
+        return [member.name for member in obj.participating_members.all()]
+
+    def validate(self, data):
+        # start_time과 end_time 검증
+        if data["end_time"] <= data["start_time"]:
             raise serializers.ValidationError("end_time은 start_time 이후여야 합니다.")
         return data

--- a/Schedules/urls.py
+++ b/Schedules/urls.py
@@ -9,4 +9,3 @@ urlpatterns = [
         "group/<int:group_id>/", GroupScheduleListView.as_view(), name="group_schedule"
     ),
 ]
-

--- a/Schedules/urls.py
+++ b/Schedules/urls.py
@@ -4,10 +4,9 @@ from .views import *
 
 urlpatterns = [
     path("", ScheduleListView.as_view(), name="schedule"),
-    path("create/", ScheduleCreateView.as_view(), name="schedule_create"),
     path("<int:pk>/", ScheduleDetailView.as_view(), name="schedule_detail"),
-    path("<int:pk>/update/", ScheduleUpdateView.as_view(), name="schedule_update"),
     path(
         "group/<int:group_id>/", GroupScheduleListView.as_view(), name="group_schedule"
     ),
 ]
+

--- a/Schedules/views.py
+++ b/Schedules/views.py
@@ -1,3 +1,4 @@
+from django.db.models import prefetch_related_objects
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.response import Response
@@ -10,28 +11,51 @@ from .serializer import ScheduleSerializer
 
 class ScheduleListView(APIView):
     """
-    일정 목록 조회
+    일정 목록 조회 및 등록
     """
 
     def get(self, request):
         schedules = Schedule.objects.all()
         serializer = ScheduleSerializer(schedules, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response({"data": serializer.data}, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        # 일정 등록
+        serializer = ScheduleSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response({"data": serializer.data}, status=status.HTTP_201_CREATED)
+        return Response(
+            {"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST
+        )
 
 
 class ScheduleDetailView(APIView):
     """
-    특정 일정 상세 조회 및 삭제
+    특정 일정 상세 조회, 수정 및 삭제
     """
 
     permission_classes = [IsAdminOrReadOnly]
 
     def get(self, request, pk):
+        # 일정 상세 조회
         schedule = get_object_or_404(Schedule, pk=pk)
         serializer = ScheduleSerializer(schedule)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response({"data": serializer.data}, status=status.HTTP_200_OK)
+
+    def patch(self, request, pk):
+        # 일정 부분 수정
+        schedule = get_object_or_404(Schedule, pk=pk)
+        serializer = ScheduleSerializer(schedule, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response({"data": serializer.data}, status=status.HTTP_200_OK)
+        return Response(
+            {"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST
+        )
 
     def delete(self, request, pk):
+        # 일정 삭제
         schedule = get_object_or_404(Schedule, pk=pk)
         deleted_schedule_data = {
             "schedule.id": schedule.id,
@@ -41,48 +65,9 @@ class ScheduleDetailView(APIView):
 
         schedule.delete()
         return Response(
-            {
-                "message": "일정이 삭제되었습니다.",
-                "deleted_schedule_data": deleted_schedule_data,
-            },
+            {"data": deleted_schedule_data},
             status=status.HTTP_200_OK,
         )
-
-
-class ScheduleCreateView(APIView):
-    """
-    새 일정 생성
-    """
-
-    permission_classes = [IsAdminOrReadOnly]
-
-    def post(self, request):
-        serializer = ScheduleSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class ScheduleUpdateView(APIView):
-    """
-    일정 업데이트
-    """
-
-    permission_classes = [IsAdminOrReadOnly]
-
-    def post(self, request, pk):
-        schedule = get_object_or_404(Schedule, pk=pk)
-
-        # 기존 객체 업데이트를 위해 instance 전달
-        serializer = ScheduleSerializer(instance=schedule, data=request.data)
-        if serializer.is_valid():
-            # 데이터 저장
-            serializer.save()
-
-            # 업데이트 된 데이터를 반환
-            return Response(serializer.data, status=status.HTTP_200_OK)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class GroupScheduleListView(APIView):
@@ -92,6 +77,8 @@ class GroupScheduleListView(APIView):
 
     def get(self, request, group_id):
         # 특정 그룹의 일정 필터링
-        schedules = Schedule.objects.filter(group_id=group_id)
+        schedules = (Schedule.objects.filter(group_id=group_id).prefetch_related("participating_members"))
+
         serializer = ScheduleSerializer(schedules, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response({"data": serializer.data}, status=status.HTTP_200_OK)
+

--- a/Schedules/views.py
+++ b/Schedules/views.py
@@ -1,4 +1,8 @@
-from rest_framework.generics import ListCreateAPIView, ListAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import (
+    ListAPIView,
+    ListCreateAPIView,
+    RetrieveUpdateDestroyAPIView,
+)
 from rest_framework.response import Response
 
 from .models import Schedule
@@ -10,6 +14,7 @@ class ScheduleListView(ListCreateAPIView):
     """
     일정 목록 조회 및 등록
     """
+
     queryset = Schedule.objects.all()
     serializer_class = ScheduleSerializer
     permission_classes = [IsAdminOrReadOnly]
@@ -19,10 +24,12 @@ class ScheduleListView(ListCreateAPIView):
         context["request"] = self.request  # request 객체를 context에 추가
         return context
 
+
 class ScheduleDetailView(RetrieveUpdateDestroyAPIView):
     """
     특정 일정 상세 조회, 수정 및 삭제
     """
+
     queryset = Schedule.objects.all()
     serializer_class = ScheduleSerializer
     permission_classes = [IsAdminOrReadOnly]
@@ -40,13 +47,16 @@ class ScheduleDetailView(RetrieveUpdateDestroyAPIView):
             {"data": deleted_schedule_data},
         )
 
+
 class GroupScheduleListView(ListAPIView):
     """
     특정 그룹의 일정 필터링
     """
+
     serializer_class = ScheduleSerializer
 
     def get_queryset(self):
         group_id = self.kwargs["group_id"]
-        return Schedule.objects.filter(group_id=group_id).prefetch_related("participating_members")
-
+        return Schedule.objects.filter(group_id=group_id).prefetch_related(
+            "participating_members"
+        )

--- a/Schedules/views.py
+++ b/Schedules/views.py
@@ -1,84 +1,47 @@
-from django.db.models import prefetch_related_objects
-from django.shortcuts import get_object_or_404
-from rest_framework import status
+from rest_framework.generics import ListCreateAPIView, ListAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from .models import Schedule
 from .permissions import IsAdminOrReadOnly
 from .serializer import ScheduleSerializer
 
 
-class ScheduleListView(APIView):
+class ScheduleListView(ListCreateAPIView):
     """
     일정 목록 조회 및 등록
     """
+    queryset = Schedule.objects.all()
+    serializer_class = ScheduleSerializer
+    permission_classes = [IsAdminOrReadOnly]
 
-    def get(self, request):
-        schedules = Schedule.objects.all()
-        serializer = ScheduleSerializer(schedules, many=True)
-        return Response({"data": serializer.data}, status=status.HTTP_200_OK)
-
-    def post(self, request):
-        # 일정 등록
-        serializer = ScheduleSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response({"data": serializer.data}, status=status.HTTP_201_CREATED)
-        return Response(
-            {"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST
-        )
-
-
-class ScheduleDetailView(APIView):
+class ScheduleDetailView(RetrieveUpdateDestroyAPIView):
     """
     특정 일정 상세 조회, 수정 및 삭제
     """
-
+    queryset = Schedule.objects.all()
+    serializer_class = ScheduleSerializer
     permission_classes = [IsAdminOrReadOnly]
 
-    def get(self, request, pk):
-        # 일정 상세 조회
-        schedule = get_object_or_404(Schedule, pk=pk)
-        serializer = ScheduleSerializer(schedule)
-        return Response({"data": serializer.data}, status=status.HTTP_200_OK)
-
-    def patch(self, request, pk):
-        # 일정 부분 수정
-        schedule = get_object_or_404(Schedule, pk=pk)
-        serializer = ScheduleSerializer(schedule, data=request.data, partial=True)
-        if serializer.is_valid():
-            serializer.save()
-            return Response({"data": serializer.data}, status=status.HTTP_200_OK)
-        return Response(
-            {"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST
-        )
-
-    def delete(self, request, pk):
-        # 일정 삭제
-        schedule = get_object_or_404(Schedule, pk=pk)
+    def delete(self, request, *args, **kwargs):
+        instance = self.get_object()
         deleted_schedule_data = {
-            "schedule.id": schedule.id,
-            "group_id": schedule.group_id,
-            "title": schedule.title,
+            "schedule.id": instance.id,
+            "group_id": instance.group_id,
+            "title": instance.title,
         }
+        self.perform_destroy(instance)
 
-        schedule.delete()
         return Response(
             {"data": deleted_schedule_data},
-            status=status.HTTP_200_OK,
         )
 
-
-class GroupScheduleListView(APIView):
+class GroupScheduleListView(ListAPIView):
     """
     특정 그룹의 일정 필터링
     """
+    serializer_class = ScheduleSerializer
 
-    def get(self, request, group_id):
-        # 특정 그룹의 일정 필터링
-        schedules = (Schedule.objects.filter(group_id=group_id).prefetch_related("participating_members"))
-
-        serializer = ScheduleSerializer(schedules, many=True)
-        return Response({"data": serializer.data}, status=status.HTTP_200_OK)
+    def get_queryset(self):
+        group_id = self.kwargs["group_id"]
+        return Schedule.objects.filter(group_id=group_id).prefetch_related("participating_members")
 

--- a/Schedules/views.py
+++ b/Schedules/views.py
@@ -14,6 +14,11 @@ class ScheduleListView(ListCreateAPIView):
     serializer_class = ScheduleSerializer
     permission_classes = [IsAdminOrReadOnly]
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["request"] = self.request  # request 객체를 context에 추가
+        return context
+
 class ScheduleDetailView(RetrieveUpdateDestroyAPIView):
     """
     특정 일정 상세 조회, 수정 및 삭제


### PR DESCRIPTION
Schedule의 전체 코드를 genericview로 리펙토링 진행했습니다.

참여 멤버를 등록할 때에는 멤버 아이디로 등록하고
등록된 내역을 확인 할 때에는 이름으로 표시되도록 로직을 수정했습니다.

스케줄 등록 시 사용자가 자동으로 지정되도록 로직을 등록했습니다.

기존 SlugRelated 대신 Prefetch_related를 사용하여 쿼리 최적화를 진행하였습니다.